### PR TITLE
fix(ci): let build report on the merge-queue ref

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,6 +4,13 @@ on:
   pull_request: {}
   workflow_dispatch: {}
 
+  # The merge queue needs `build` to report on the queue ref. merge_group is not
+  # dispatching org-wide, so mirror the push-on-queue-ref trigger the review
+  # workflows already use.
+  push:
+    branches:
+      - gh-readonly-queue/**
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
**What:** Adds the `push` trigger on `gh-readonly-queue/**` to `build.yml`'s `on:` block. Nothing else in the file changes.

**Why:** `build` is a required status check, and the merge queue re-runs required checks on its own `gh-readonly-queue/**` ref. `merge_group` is not dispatching org-wide (last such event was 2026-03-09), so this `push` trigger is the only way `build` reports on a queue ref. Without it the queue waits for a check that can never arrive, so the PR cannot merge.

Measured across `p6m7g8`: 27 of 30 targets were missing it.

**Why this is a hand-rolled patch and not distribution.** `p6-gh-workflow-distribute` deliberately skips `build.yml` when a target's build action differs from its org template, and it cannot own these files: they carry per-repo `with:` inputs (`aws_role`, `aws_session_name`, `cdk_deploy_account`, `cdk_deploy_region`), and in some repos a `permissions:` block and a `container:` image. An archetype-template approach was tried and abandoned for exactly this reason — see p6m7g8-actions/p6-gh-workflow-distribute#16. So the trigger is backfilled surgically instead.

**Test plan:** The patch inserts into the `on:` mapping only. Verified on a real file that everything from `jobs:` onward is byte-identical, that the parsed non-trigger top-level keys and the whole `jobs` tree are unchanged, and that re-running is a no-op. This PR's own `build` run exercises the result, and the merge itself is the proof: this PR is the first in the repo whose `build` can report on the queue ref.

**Dependencies:** none.
