### PR TITLE
fix(ci): restore build.yml trailing newline and renamed build action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,7 +20,7 @@ jobs:
       image: jsii/superchain:1-bookworm-slim-node24
     steps:
       - name: CDK Construct Build
-        uses: p6m7g8-actions/cdk-construct-build@main
+        uses: p6m7g8-actions/p6-cdk-construct-build@main
         with:
           aws_region: ${{ secrets.CDK_DEPLOY_REGION }}
           aws_role: ${{ secrets.AWS_ROLE }}


### PR DESCRIPTION
See commit message. Restores the trailing newline yamllint requires, and re-applies the build-action rename that the distribution merge reverted. The queue-ref trigger is preserved.